### PR TITLE
Remove getTable call

### DIFF
--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
@@ -68,7 +68,6 @@ public class BigQueryStreamingOutputFormat extends AbstractBigQueryOutputFormat 
         final Object value = retrieveValue(record, fieldTypes[i], i);
         rowContent.put(fieldNames[i], value);
       }
-      bigQuery.getTable(TableId.of("aiven-opensource-sandbox", "TestDataSet", "strTest"));
       InsertAllRequest.Builder builder = InsertAllRequest.newBuilder(options.getTableId());
       builder.addRow(rowContent);
       Map<Long, List<BigQueryError>> insertErrors =


### PR DESCRIPTION
The call is obviously unnecessary, it gets a hard-code table in aiven-opensource-sandbox project.