### PR TITLE
Autocreate tables on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ CREATE TEMPORARY TABLE array_row_example (
 ```
 If dataset `MyDataset` does not exist connector will create it, same for table `MyTable`
 It is worth to mention that Flink's for `ARRAY` type it will create `REPEATED` field in BigQuery,
-for Flink's `ROW` type it will create `STRUCT` type in BigQuery. also depending on nullability specified in schema 
+for Flink's `ROW` type it will create `STRUCT` type in BigQuery. Also depending on nullability specified in schema 
 it will create `REQUIRED` or `NULLABLE` type in BigQuery.

--- a/README.md
+++ b/README.md
@@ -64,3 +64,25 @@ CREATE TEMPORARY TABLE array_row_example (
 ```sql
 INSERT INTO array_row_example VALUES(array[1, 2, 3], row('fullname', 123));
 ```
+
+## Table autocreation
+Connector could create datasets and tables in BigQuery based on schema in case there is enough grants for that.
+To enable this feature use `'table-create-if-not-exists'='true'` property (`false` by default)
+For instance
+```sql
+CREATE TEMPORARY TABLE array_row_example (
+    `numbers` ARRAY<INT>,
+    `persons` ROW<name STRING, age INT>
+) WITH (
+    'connector' = 'bigquery',
+    'service-account' = <PATH_TO_SERVICE_ACCOUNT>,
+    'project-id' = 'MyProject',
+    'dataset' = 'MyDataset',
+    'table' = 'MyTable',
+    'table-create-if-not-exists'='true'
+);
+```
+If dataset `MyDataset` does not exist connector will create it, same for table `MyTable`
+It is worth to mention that Flink's for `ARRAY` type it will create `REPEATED` field in BigQuery,
+for Flink's `ROW` type it will create `STRUCT` type in BigQuery. also depending on nullability specified in schema 
+it will create `REQUIRED` or `NULLABLE` type in BigQuery.

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/AbstractBigQueryOutputFormat.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/AbstractBigQueryOutputFormat.java
@@ -1,5 +1,6 @@
 package io.aiven.flink.connectors.bigquery.sink;
 
+import com.google.cloud.bigquery.Table;
 import java.util.Arrays;
 import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.configuration.Configuration;
@@ -35,6 +36,8 @@ public abstract class AbstractBigQueryOutputFormat extends RichOutputFormat<RowD
 
     private BigQueryConnectionOptions options;
 
+    private Table table;
+
     public Builder() {}
 
     public Builder withFieldDataTypes(DataType[] fieldDataTypes) {
@@ -52,6 +55,11 @@ public abstract class AbstractBigQueryOutputFormat extends RichOutputFormat<RowD
       return this;
     }
 
+    public Builder withTable(Table table) {
+      this.table = table;
+      return this;
+    }
+
     public AbstractBigQueryOutputFormat build() {
       Preconditions.checkNotNull(fieldNames);
       Preconditions.checkNotNull(fieldDataTypes);
@@ -61,7 +69,7 @@ public abstract class AbstractBigQueryOutputFormat extends RichOutputFormat<RowD
     }
 
     private BigQueryStreamingOutputFormat createBatchOutputFormat(LogicalType[] logicalTypes) {
-      return new BigQueryStreamingOutputFormat(fieldNames, logicalTypes, options);
+      return new BigQueryStreamingOutputFormat(fieldNames, logicalTypes, options, table);
     }
   }
 }

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConfigOptions.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConfigOptions.java
@@ -9,11 +9,13 @@ public class BigQueryConfigOptions {
           .stringType()
           .noDefaultValue()
           .withDescription("The path to service account key.");
+
   public static final ConfigOption<String> PROJECT_ID =
       ConfigOptions.key("project-id")
           .stringType()
           .noDefaultValue()
           .withDescription("Google Cloud Project id.");
+
   public static final ConfigOption<String> DATASET =
       ConfigOptions.key("dataset")
           .stringType()
@@ -21,4 +23,10 @@ public class BigQueryConfigOptions {
           .withDescription("BigQuery dataset.");
   public static final ConfigOption<String> TABLE =
       ConfigOptions.key("table").stringType().noDefaultValue().withDescription("BigQuery table.");
+
+  public static final ConfigOption<Boolean> CREATE_TABLE_IF_NOT_PRESENT =
+      ConfigOptions.key("table-create-if-not-exists")
+          .booleanType()
+          .defaultValue(Boolean.FALSE)
+          .withDescription("Determines whether table should be created if not exists");
 }

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectionOptions.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectionOptions.java
@@ -13,11 +13,18 @@ public class BigQueryConnectionOptions implements Serializable {
   private final String dataset;
   private final String table;
 
+  private final boolean createIfNotExists;
+
   public BigQueryConnectionOptions(
-      String project, String dataset, String table, Credentials credentials) {
+      String project,
+      String dataset,
+      String table,
+      boolean createIfNotExists,
+      Credentials credentials) {
     this.project = project;
     this.dataset = dataset;
     this.table = table;
+    this.createIfNotExists = createIfNotExists;
     this.credentials = credentials;
   }
 
@@ -27,5 +34,9 @@ public class BigQueryConnectionOptions implements Serializable {
 
   public Credentials getCredentials() {
     return credentials;
+  }
+
+  public boolean isCreateIfNotExists() {
+    return createIfNotExists;
   }
 }

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySink.java
@@ -1,5 +1,24 @@
 package io.aiven.flink.connectors.bigquery.sink;
 
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -7,8 +26,40 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 public class BigQuerySink implements DynamicTableSink {
+  private static final Map<LogicalTypeRoot, StandardSQLTypeName> DATATYPE_2_BIGQUERY_TYPE =
+      new EnumMap<>(LogicalTypeRoot.class);
+
+  static {
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.VARCHAR, StandardSQLTypeName.STRING);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.INTEGER, StandardSQLTypeName.INT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.TINYINT, StandardSQLTypeName.INT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.SMALLINT, StandardSQLTypeName.INT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.BIGINT, StandardSQLTypeName.INT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.FLOAT, StandardSQLTypeName.FLOAT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.DOUBLE, StandardSQLTypeName.FLOAT64);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE, StandardSQLTypeName.TIME);
+    DATATYPE_2_BIGQUERY_TYPE.put(
+        LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE, StandardSQLTypeName.TIMESTAMP);
+    DATATYPE_2_BIGQUERY_TYPE.put(
+        LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, StandardSQLTypeName.TIMESTAMP);
+    DATATYPE_2_BIGQUERY_TYPE.put(
+        LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE, StandardSQLTypeName.TIMESTAMP);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.DATE, StandardSQLTypeName.DATE);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.BOOLEAN, StandardSQLTypeName.BOOL);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.DECIMAL, StandardSQLTypeName.NUMERIC);
+    DATATYPE_2_BIGQUERY_TYPE.put(LogicalTypeRoot.ROW, StandardSQLTypeName.STRUCT);
+  }
+
+  private static final Set<LogicalTypeRoot> TYPES_WITH_PRECISION =
+      EnumSet.of(LogicalTypeRoot.DECIMAL);
+
+  private static final Set<LogicalTypeRoot> TYPES_WITH_SCALE = EnumSet.of(LogicalTypeRoot.DECIMAL);
+
   private final CatalogTable catalogTable;
   private final ResolvedSchema tableSchema;
   private final BigQueryConnectionOptions options;
@@ -39,6 +90,9 @@ public class BigQuerySink implements DynamicTableSink {
             .map(Column::getDataType)
             .toArray(DataType[]::new);
 
+    if (options.isCreateIfNotExists()) {
+      ensureTableExists(fieldNames, fieldTypes, options);
+    }
     AbstractBigQueryOutputFormat outputFormat =
         new AbstractBigQueryOutputFormat.Builder()
             .withFieldNames(fieldNames)
@@ -56,5 +110,90 @@ public class BigQuerySink implements DynamicTableSink {
   @Override
   public String asSummaryString() {
     return "BigQuery sink";
+  }
+
+  @VisibleForTesting
+  static Table ensureTableExists(
+      String[] fieldNames, DataType[] types, BigQueryConnectionOptions options) {
+    var bigQuery =
+        BigQueryOptions.newBuilder()
+            .setProjectId(options.getTableName().getProject())
+            .setCredentials(options.getCredentials())
+            .build()
+            .getService();
+    var dataset = options.getTableName().getDataset();
+    if (bigQuery.getDataset(dataset) == null || !bigQuery.getDataset(dataset).exists()) {
+      bigQuery.create(DatasetInfo.newBuilder(dataset).build());
+    }
+    var tableId =
+        TableId.of(
+            options.getTableName().getProject(),
+            options.getTableName().getDataset(),
+            options.getTableName().getTable());
+    Table table = bigQuery.getTable(tableId);
+    if (table == null || !table.exists()) {
+      return bigQuery.create(
+          TableInfo.of(
+              tableId,
+              StandardTableDefinition.newBuilder()
+                  .setSchema(schemaBuilder(fieldNames, types))
+                  .build()));
+    }
+    return table;
+  }
+
+  private static Schema schemaBuilder(String[] fieldNames, DataType[] types) {
+    // ARRAY of ARRAYs is not allowed based on Google BigQuery doc
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#constructing_an_array
+    Collection<Field> fields = new ArrayList<>();
+    for (int i = 0; i < fieldNames.length; i++) {
+      LogicalType logicalType = types[i].getLogicalType();
+      fields.add(buildField(fieldNames[i], logicalType));
+    }
+    return Schema.of(fields);
+  }
+
+  private static FieldList buildFieldList(LogicalType parentLogicalType) {
+    Collection<Field> fields = new ArrayList<>();
+    if (parentLogicalType.is(LogicalTypeRoot.ARRAY)) {
+      parentLogicalType = parentLogicalType.getChildren().get(0);
+    }
+    List<LogicalType> logicalTypes = LogicalTypeChecks.getFieldTypes(parentLogicalType);
+    List<String> names = LogicalTypeChecks.getFieldNames(parentLogicalType);
+    for (int i = 0; i < LogicalTypeChecks.getFieldCount(parentLogicalType); i++) {
+      LogicalType childLogicalType = logicalTypes.get(i);
+      fields.add(buildField(names.get(i), childLogicalType));
+    }
+    return FieldList.of(fields);
+  }
+
+  private static Field buildField(String fieldName, LogicalType logicalType) {
+    StandardSQLTypeName standardSQLTypeName =
+        DATATYPE_2_BIGQUERY_TYPE.get(
+            logicalType.is(LogicalTypeRoot.ARRAY)
+                ? logicalType.getChildren().get(0).getTypeRoot()
+                : logicalType.getTypeRoot());
+    if (standardSQLTypeName == null) {
+      throw new ValidationException("Type " + logicalType + " is not supported");
+    }
+    Field.Builder fBuilder;
+    if (logicalType.is(LogicalTypeRoot.ROW)
+        || logicalType.is(LogicalTypeRoot.ARRAY)
+            && logicalType.getChildren().get(0).is(LogicalTypeRoot.ROW)) {
+      fBuilder = Field.newBuilder(fieldName, standardSQLTypeName, buildFieldList(logicalType));
+    } else {
+      fBuilder = Field.newBuilder(fieldName, standardSQLTypeName);
+    }
+    fBuilder.setMode(logicalType.isNullable() ? Field.Mode.NULLABLE : Field.Mode.REQUIRED);
+    if (logicalType.is(LogicalTypeRoot.ARRAY)) {
+      fBuilder.setMode(Field.Mode.REPEATED);
+    }
+    if (TYPES_WITH_PRECISION.contains(logicalType.getTypeRoot())) {
+      fBuilder.setPrecision((long) LogicalTypeChecks.getPrecision(logicalType));
+    }
+    if (TYPES_WITH_SCALE.contains(logicalType.getTypeRoot())) {
+      fBuilder.setScale((long) LogicalTypeChecks.getScale(logicalType));
+    }
+    return fBuilder.build();
   }
 }

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
@@ -11,6 +11,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.storage.v1.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -69,13 +70,17 @@ public class BigQueryStreamingOutputFormat extends AbstractBigQueryOutputFormat 
 
   private final BigQueryConnectionOptions options;
 
+  private Table table;
+
   protected BigQueryStreamingOutputFormat(
       @Nonnull String[] fieldNames,
       @Nonnull LogicalType[] fieldTypes,
-      @Nonnull BigQueryConnectionOptions options) {
+      @Nonnull BigQueryConnectionOptions options,
+      Table table) {
     this.fieldNames = Preconditions.checkNotNull(fieldNames);
     this.fieldTypes = Preconditions.checkNotNull(fieldTypes);
     this.options = Preconditions.checkNotNull(options);
+    this.table = table;
   }
 
   @Override

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryTableSinkFactory.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryTableSinkFactory.java
@@ -1,5 +1,6 @@
 package io.aiven.flink.connectors.bigquery.sink;
 
+import static io.aiven.flink.connectors.bigquery.sink.BigQueryConfigOptions.CREATE_TABLE_IF_NOT_PRESENT;
 import static io.aiven.flink.connectors.bigquery.sink.BigQueryConfigOptions.DATASET;
 import static io.aiven.flink.connectors.bigquery.sink.BigQueryConfigOptions.PROJECT_ID;
 import static io.aiven.flink.connectors.bigquery.sink.BigQueryConfigOptions.SERVICE_ACCOUNT;
@@ -18,7 +19,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 
 public class BigQueryTableSinkFactory implements DynamicTableSinkFactory {
   private static final Set<ConfigOption<?>> REQUIRED_OPTIONS =
-      Set.of(SERVICE_ACCOUNT, PROJECT_ID, DATASET, TABLE);
+      Set.of(SERVICE_ACCOUNT, PROJECT_ID, DATASET, TABLE, CREATE_TABLE_IF_NOT_PRESENT);
 
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
@@ -35,6 +36,7 @@ public class BigQueryTableSinkFactory implements DynamicTableSinkFactory {
             helper.getOptions().get(PROJECT_ID),
             helper.getOptions().get(DATASET),
             helper.getOptions().get(TABLE),
+            helper.getOptions().get(CREATE_TABLE_IF_NOT_PRESENT),
             credentials);
     return new BigQuerySink(
         context.getCatalogTable(), context.getCatalogTable().getResolvedSchema(), options);

--- a/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
@@ -80,6 +80,7 @@ public class FlinkBigQueryConnectorIntegrationTest {
                 + BIG_QUERY_PROJECT_ID
                 + "',"
                 + "  'dataset' = 'TestDataSet',"
+                + "  'table-create-if-not-exists' = 'true',"
                 + "  'table' = 'test-table'"
                 + ")")
         .await();

--- a/src/test/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySinkTest.java
@@ -1,0 +1,104 @@
+package io.aiven.flink.connectors.bigquery.sink;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BigQuerySinkTest {
+  private static final Map<String, String> ENV_PROP_MAP = System.getenv();
+  private static final String BIG_QUERY_SERVICE_ACCOUNT =
+      ENV_PROP_MAP.get("BIG_QUERY_SERVICE_ACCOUNT");
+  private static final String BIG_QUERY_PROJECT_ID = ENV_PROP_MAP.get("BIG_QUERY_PROJECT_ID");
+  private static final String DATASET_NAME = "TestDataSet";
+  private static final Credentials CREDENTIALS;
+
+  static {
+    try (FileInputStream fis = new FileInputStream(BIG_QUERY_SERVICE_ACCOUNT)) {
+      CREDENTIALS = ServiceAccountCredentials.fromStream(fis);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("datatypeProvider")
+  void tableCreationTest(String tableName, String[] fieldNames, DataType[] fieldTypes) {
+    BigQueryConnectionOptions options =
+        new BigQueryConnectionOptions(
+            BIG_QUERY_PROJECT_ID, DATASET_NAME, tableName, true, CREDENTIALS);
+    var table = BigQuerySink.ensureTableExists(fieldNames, fieldTypes, options);
+    table.delete();
+  }
+
+  static Stream<Arguments> datatypeProvider() {
+    return Stream.of(
+        Arguments.of(
+            "decimal-test",
+            new String[] {"decimal10_5_notNull"},
+            new DataType[] {DataTypes.DECIMAL(10, 5).notNull()}),
+        Arguments.of(
+            "int-test", new String[] {"int_notNull"}, new DataType[] {DataTypes.INT().notNull()}),
+        Arguments.of(
+            "array-test",
+            new String[] {"array_of_strings"},
+            new DataType[] {DataTypes.ARRAY(DataTypes.STRING()).notNull()}),
+        Arguments.of(
+            "array-row-array-string-int-test",
+            new String[] {"row_of_string_int"},
+            new DataType[] {
+              DataTypes.ARRAY(DataTypes.ROW(DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT()))))
+                  .notNull()
+            }),
+        Arguments.of(
+            "row-array-row-array-string-int-test",
+            new String[] {"row_of_string_int"},
+            new DataType[] {
+              DataTypes.ROW(
+                      DataTypes.ARRAY(DataTypes.ROW(DataTypes.ARRAY(DataTypes.INT()))),
+                      DataTypes.INT())
+                  .notNull()
+            }),
+        Arguments.of(
+            "row-string-int-test",
+            new String[] {"row_of_string_int"},
+            new DataType[] {DataTypes.ROW(DataTypes.STRING(), DataTypes.INT()).notNull()}),
+        Arguments.of(
+            "row-row-string-int-test",
+            new String[] {"row_row_of_string_int"},
+            new DataType[] {
+              DataTypes.ROW(
+                      DataTypes.ROW(DataTypes.DECIMAL(4, 3)), DataTypes.STRING(), DataTypes.INT())
+                  .notNull()
+            }),
+        Arguments.of(
+            "row-row-row-string-int-test",
+            new String[] {"row_row_row_of_string_int"},
+            new DataType[] {
+              DataTypes.ROW(
+                      DataTypes.ROW(DataTypes.ROW(DataTypes.DATE()), DataTypes.DECIMAL(4, 3)),
+                      DataTypes.STRING(),
+                      DataTypes.INT())
+                  .notNull()
+            }),
+        Arguments.of(
+            "row-row-row-array-string-int-test",
+            new String[] {"row_row_row_of_string_int"},
+            new DataType[] {
+              DataTypes.ROW(
+                      DataTypes.ROW(
+                          DataTypes.ROW(DataTypes.ARRAY(DataTypes.DATE())),
+                          DataTypes.DECIMAL(4, 3)),
+                      DataTypes.STRING(),
+                      DataTypes.INT())
+                  .notNull()
+            }));
+  }
+}


### PR DESCRIPTION
About this change - What it does
It enables autocreation of datasets and tables based on specified schema in case there is enough grants for that.
By default it is turned off
To enable it there should be specified property `'table-create-if-not-exists'='true'`
it respects nullability, arrays(repeated), rows (structs) and in case of decimal precision and scale
Resolves: #13
Why this way
