### PR TITLE
Make spotless run in validate stage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                 <executions>
                     <execution>
                         <id>spotless-check</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
About this change - What it does
This makes spotless run before compilation and it makes spotless running on ci
proof (https://github.com/aiven/bigquery-connector-for-apache-flink/actions/runs/5487116988/jobs/9998125414?pr=22#step:4:18)
Resolves: #xxxxx
Why this way
