### PR TITLE
Add registration of PickFirstLoadBalancerProvider 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11 ]
-        runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
+        runs-on: [ ubuntu-latest, macos-latest ]
     name: Test on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -41,4 +41,4 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: test with Maven
-        run: mvn test -Dtest=!FlinkBigQueryConnectorIntegrationTest
+        run: mvn test -Dtest=\!FlinkBigQueryConnectorIntegrationTest,\!BigQuerySinkTest

--- a/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -1,0 +1,1 @@
+io.grpc.internal.PickFirstLoadBalancerProvider


### PR DESCRIPTION
About this change - What it does
`PickFirstLoadBalancerProvider` should be registered
also makes ci passing (Win does not respect `\`  so tests for code coverage for win are removed)
Resolves: #xxxxx
Why this way
