### PR TITLE
Shade dependencies and add null checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,48 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-compat-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -72,12 +114,6 @@
             <version>${flink.version}</version>
             <type>pom</type>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-json</artifactId>
-            <version>${flink.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -255,10 +291,73 @@
                                 <excludes>
                                     <exclude>org.apache.flink:force-shading</exclude>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>log4j:*</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>google</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>grpc</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.grpc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.grpc</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.io.grpc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.io.netty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.opencensus</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.io.opencensus</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.perfmark</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.io.perfmark</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.json</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.json</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.arrow</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.apache.arrow</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>codegen</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.codegen</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.mojo</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.codehaus.mojo</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.conscrypt</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.conscrypt</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.threeten</pattern>
+                                    <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.threeten</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,6 @@
                                 <excludes>
                                     <exclude>org.apache.flink:force-shading</exclude>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
-                                    <exclude>com.google.code.findbugs:jsr305</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>log4j:*</exclude>
                                 </excludes>

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryStreamingOutputFormat.java
@@ -107,11 +107,17 @@ public class BigQueryStreamingOutputFormat extends AbstractBigQueryOutputFormat 
 
   @Override
   public void close() {
-    // Wait for all in-flight requests to complete.
-    inflightRequestCount.arriveAndAwaitAdvance();
+    // An error could happen before init of inflightRequestCount
+    if (inflightRequestCount != null) {
+      // Wait for all in-flight requests to complete.
+      inflightRequestCount.arriveAndAwaitAdvance();
+    }
 
-    // Close the connection to the server.
-    streamWriter.close();
+    // streamWriter could fail to init
+    if (streamWriter != null) {
+      // Close the connection to the server.
+      streamWriter.close();
+    }
 
     // Verify that no error occurred in the stream.
     synchronized (this.lock) {


### PR DESCRIPTION
It seems we faced the situation when several connectors have similar dependencies however different versions...
As a result there is a clash of classes.

The PR makes shading of deps.
Also it was noticed that sometimes it could happen that because of error some initialization are not happened in `open` (e.g. because of clash of deps) in close there will NPE while trying to close resources