### PR TITLE
Transform META-INF/services when shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,9 @@
                                     <shadedPattern>io.aiven.flink.connectors.bigquery.shaded.org.threeten</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>


### PR DESCRIPTION
When shading third-party jars, we need to ensure that the service loader mechanism can still find implementations.

Before this change, in the `META-INF/services` folder:

`io.grpc.ManagedChannelProvider` contains:
```
io.grpc.netty.shaded.io.grpc.netty.NettyChannelProvider
```

After this change:
`io.aiven.flink.connectors.bigquery.shaded.io.grpc.ManagedChannelProvider` contains:
```
io.aiven.flink.connectors.bigquery.shaded.io.grpc.netty.shaded.io.grpc.netty.NettyChannelProvider
io.aiven.flink.connectors.bigquery.shaded.io.grpc.netty.shaded.io.grpc.netty.UdsNettyChannelProvider
```