### PR TITLE
Show actual error message in case of schema violations

### DIFF
--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/AbstractBigQueryOutputFormat.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/AbstractBigQueryOutputFormat.java
@@ -15,7 +15,6 @@ import com.google.protobuf.Descriptors;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.rmi.RemoteException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectorRuntimeException.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectorRuntimeException.java
@@ -1,0 +1,22 @@
+package io.aiven.flink.connectors.bigquery.sink;
+
+public class BigQueryConnectorRuntimeException extends RuntimeException {
+    public BigQueryConnectorRuntimeException() {
+    }
+
+    public BigQueryConnectorRuntimeException(String message) {
+        super(message);
+    }
+
+    public BigQueryConnectorRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BigQueryConnectorRuntimeException(Throwable cause) {
+        super(cause);
+    }
+
+    public BigQueryConnectorRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectorRuntimeException.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryConnectorRuntimeException.java
@@ -1,22 +1,22 @@
 package io.aiven.flink.connectors.bigquery.sink;
 
 public class BigQueryConnectorRuntimeException extends RuntimeException {
-    public BigQueryConnectorRuntimeException() {
-    }
+  public BigQueryConnectorRuntimeException() {}
 
-    public BigQueryConnectorRuntimeException(String message) {
-        super(message);
-    }
+  public BigQueryConnectorRuntimeException(String message) {
+    super(message);
+  }
 
-    public BigQueryConnectorRuntimeException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public BigQueryConnectorRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public BigQueryConnectorRuntimeException(Throwable cause) {
-        super(cause);
-    }
+  public BigQueryConnectorRuntimeException(Throwable cause) {
+    super(cause);
+  }
 
-    public BigQueryConnectorRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
+  public BigQueryConnectorRuntimeException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
 }

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySink.java
@@ -214,7 +214,7 @@ public class BigQuerySink implements DynamicTableSink {
       }
       if (existingFieldMode != Field.Mode.NULLABLE
           && fieldFromInsert.getMode() == Field.Mode.NULLABLE) {
-        if (parentName != null) {
+        if (!parentName.isBlank()) {
           // currently this is a bug in Calcite/Flink
           // so this validation will be done at runtime on BigQuery side
           fieldIndex++;
@@ -232,7 +232,7 @@ public class BigQuerySink implements DynamicTableSink {
                 + fieldFromInsert.getType().getStandardType()
                 + "'");
       }
-      if (existingField.getType() == LegacySQLTypeName.RECORD) {
+      if (LegacySQLTypeName.RECORD.equals(existingField.getType())) {
         validateTableDefinitions(
             existingField.getSubFields(), fieldFromInsert.getSubFields(), existingField.getName());
       }
@@ -240,7 +240,7 @@ public class BigQuerySink implements DynamicTableSink {
     }
     if (fieldIndex != fieldList.size()) {
       throw new ValidationException(
-          "There are unknown columns starting  with #"
+          "There are unknown columns starting with #"
               + (fieldIndex + 1)
               + " with name '"
               + parentName

--- a/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryTableSinkFactory.java
+++ b/src/main/java/io/aiven/flink/connectors/bigquery/sink/BigQueryTableSinkFactory.java
@@ -49,7 +49,10 @@ public class BigQueryTableSinkFactory implements DynamicTableSinkFactory {
             config.get(DELIVERY_GUARANTEE),
             credentials);
     return new BigQuerySink(
-        context.getCatalogTable(), context.getCatalogTable().getResolvedSchema(), options);
+        context.getCatalogTable(),
+        context.getCatalogTable().getResolvedSchema(),
+        context.getPhysicalRowDataType(),
+        options);
   }
 
   @Override

--- a/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
@@ -1,9 +1,7 @@
 package io.aiven.flink.connectors.bigquery;
 
 import static org.apache.flink.table.api.Expressions.row;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.aiven.flink.connectors.bigquery.sink.BigQueryConnectorRuntimeException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,7 +40,8 @@ public class FlinkBigQueryConnectorIntegrationTest {
             Column.metadata("tmp9", DataTypes.TIMESTAMP(9).nullable(), null, false),
             Column.metadata("date", DataTypes.DATE().nullable(), null, false),
             Column.metadata("time", DataTypes.TIME().nullable(), null, false),
-            Column.metadata("array", DataTypes.ARRAY(DataTypes.INT()).nullable(), null, false),
+            Column.metadata(
+                "array", DataTypes.ARRAY(DataTypes.INT().notNull()).nullable(), null, false),
             Column.metadata(
                 "row",
                 DataTypes.ROW(
@@ -54,7 +53,7 @@ public class FlinkBigQueryConnectorIntegrationTest {
             Column.metadata("decimal", DataTypes.DECIMAL(5, 3).nullable(), null, false),
             Column.metadata(
                 "decimal_array",
-                DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).nullable()).nullable(),
+                DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).notNull()).nullable(),
                 null,
                 false));
     tableEnv
@@ -69,10 +68,10 @@ public class FlinkBigQueryConnectorIntegrationTest {
                 + "  `tmp9` TIMESTAMP(9),\n"
                 + "  `date` DATE,\n"
                 + "  `time` TIME,\n"
-                + "  `array` ARRAY<INT>,\n"
+                + "  `array` ARRAY<INT NOT NULL>,\n"
                 + "  `row` ROW<string_field STRING, int_field INT, date_field DATE>,\n"
                 + "  `decimal` DECIMAL(5, 3),\n"
-                + "  `decimal_array` ARRAY<DECIMAL(7, 2)>\n"
+                + "  `decimal_array` ARRAY<DECIMAL(7, 2) NOT NULL>\n"
                 + ") WITH (\n"
                 + "  'connector' = 'bigquery',"
                 + "  'service-account' = '"
@@ -111,94 +110,5 @@ public class FlinkBigQueryConnectorIntegrationTest {
                 decimalArray))
         .executeInsert("test_table")
         .await();
-  }
-
-  @Test
-  public void testSinkForInvalidColumnNames() throws Exception {
-
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-    env.setParallelism(8);
-    StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
-
-    final ResolvedSchema schema =
-        ResolvedSchema.of(
-            Column.metadata("string", DataTypes.STRING().nullable(), null, false),
-            Column.metadata("int", DataTypes.INT().nullable(), null, false),
-            Column.metadata("boolean", DataTypes.BOOLEAN().nullable(), null, false),
-            Column.metadata("float", DataTypes.FLOAT().nullable(), null, false),
-            Column.metadata("double", DataTypes.DOUBLE().nullable(), null, false),
-            Column.metadata("tmp", DataTypes.TIMESTAMP().nullable(), null, false),
-            Column.metadata("tmp9", DataTypes.TIMESTAMP(9).nullable(), null, false),
-            Column.metadata("date", DataTypes.DATE().nullable(), null, false),
-            Column.metadata("time", DataTypes.TIME().nullable(), null, false),
-            Column.metadata("array", DataTypes.ARRAY(DataTypes.INT()).nullable(), null, false),
-            Column.metadata(
-                "row",
-                DataTypes.ROW(
-                    DataTypes.FIELD("string_field", DataTypes.STRING().nullable()),
-                    DataTypes.FIELD("int_field", DataTypes.INT().nullable()),
-                    DataTypes.FIELD("date_field", DataTypes.DATE().nullable())),
-                null,
-                false),
-            Column.metadata("decimal", DataTypes.DECIMAL(5, 3).nullable(), null, false),
-            Column.metadata(
-                "decimal_array",
-                DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).nullable()).nullable(),
-                null,
-                false));
-    tableEnv
-        .executeSql(
-            "CREATE TEMPORARY TABLE test_table ( \n"
-                + "  `invalid` STRING,\n"
-                + "  `int` INT,\n"
-                + "  `boolean` BOOLEAN,\n"
-                + "  `float` FLOAT,\n"
-                + "  `double` DOUBLE,\n"
-                + "  `tmp` TIMESTAMP(3),\n"
-                + "  `tmp9` TIMESTAMP(9),\n"
-                + "  `date` DATE,\n"
-                + "  `time` TIME,\n"
-                + "  `array` ARRAY<INT>,\n"
-                + "  `row` ROW<string_field STRING, int_field INT, date_field DATE>,\n"
-                + "  `decimal` DECIMAL(5, 3),\n"
-                + "  `decimal_array` ARRAY<DECIMAL(7, 2)>\n"
-                + ") WITH (\n"
-                + "  'connector' = 'bigquery',"
-                + "  'service-account' = '"
-                + BIG_QUERY_SERVICE_ACCOUNT
-                + "',"
-                + "  'project-id' = '"
-                + BIG_QUERY_PROJECT_ID
-                + "',"
-                + "  'dataset' = 'TestDataSet',"
-                + "  'table-create-if-not-exists' = 'true',"
-                + "  'table' = 'test-table'"
-                + ")")
-        .await();
-
-    BigDecimal[] decimalArray = new BigDecimal[] {BigDecimal.valueOf(12233.12), BigDecimal.TEN};
-
-    assertThatThrownBy(
-            () ->
-                tableEnv
-                    .fromValues(
-                        schema.toSinkRowDataType(),
-                        row(
-                            "123",
-                            123,
-                            false,
-                            12.345f,
-                            123.4567d,
-                            LocalDateTime.of(2021, 10, 31, 23, 34, 56),
-                            LocalDateTime.of(2021, 10, 31, 23, 34, 56, 987654312),
-                            LocalDate.of(2000, 9, 22),
-                            LocalTime.of(12, 13, 14),
-                            new int[] {1, 2, 3},
-                            Row.of("test", null, LocalDate.of(2030, 9, 25)),
-                            BigDecimal.valueOf(12.312),
-                            decimalArray))
-                    .executeInsert("test_table")
-                    .await())
-        .hasStackTraceContaining(BigQueryConnectorRuntimeException.class.getCanonicalName() + ":");
   }
 }

--- a/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
@@ -1,12 +1,15 @@
 package io.aiven.flink.connectors.bigquery;
 
 import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
+
+import io.aiven.flink.connectors.bigquery.sink.BigQueryConnectorRuntimeException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -109,5 +112,92 @@ public class FlinkBigQueryConnectorIntegrationTest {
                 decimalArray))
         .executeInsert("test_table")
         .await();
+  }
+
+  @Test
+  public void testSinkForInvalidColumnNames() throws Exception {
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(8);
+    StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+    final ResolvedSchema schema =
+            ResolvedSchema.of(
+                    Column.metadata("string", DataTypes.STRING().nullable(), null, false),
+                    Column.metadata("int", DataTypes.INT().nullable(), null, false),
+                    Column.metadata("boolean", DataTypes.BOOLEAN().nullable(), null, false),
+                    Column.metadata("float", DataTypes.FLOAT().nullable(), null, false),
+                    Column.metadata("double", DataTypes.DOUBLE().nullable(), null, false),
+                    Column.metadata("tmp", DataTypes.TIMESTAMP().nullable(), null, false),
+                    Column.metadata("tmp9", DataTypes.TIMESTAMP(9).nullable(), null, false),
+                    Column.metadata("date", DataTypes.DATE().nullable(), null, false),
+                    Column.metadata("time", DataTypes.TIME().nullable(), null, false),
+                    Column.metadata("array", DataTypes.ARRAY(DataTypes.INT()).nullable(), null, false),
+                    Column.metadata(
+                            "row",
+                            DataTypes.ROW(
+                                    DataTypes.FIELD("string_field", DataTypes.STRING().nullable()),
+                                    DataTypes.FIELD("int_field", DataTypes.INT().nullable()),
+                                    DataTypes.FIELD("date_field", DataTypes.DATE().nullable())),
+                            null,
+                            false),
+                    Column.metadata("decimal", DataTypes.DECIMAL(5, 3).nullable(), null, false),
+                    Column.metadata(
+                            "decimal_array",
+                            DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).nullable()).nullable(),
+                            null,
+                            false));
+    tableEnv
+            .executeSql(
+                    "CREATE TEMPORARY TABLE test_table ( \n"
+                            + "  `invalid` STRING,\n"
+                            + "  `int` INT,\n"
+                            + "  `boolean` BOOLEAN,\n"
+                            + "  `float` FLOAT,\n"
+                            + "  `double` DOUBLE,\n"
+                            + "  `tmp` TIMESTAMP(3),\n"
+                            + "  `tmp9` TIMESTAMP(9),\n"
+                            + "  `date` DATE,\n"
+                            + "  `time` TIME,\n"
+                            + "  `array` ARRAY<INT>,\n"
+                            + "  `row` ROW<string_field STRING, int_field INT, date_field DATE>,\n"
+                            + "  `decimal` DECIMAL(5, 3),\n"
+                            + "  `decimal_array` ARRAY<DECIMAL(7, 2)>\n"
+                            + ") WITH (\n"
+                            + "  'connector' = 'bigquery',"
+                            + "  'service-account' = '"
+                            + BIG_QUERY_SERVICE_ACCOUNT
+                            + "',"
+                            + "  'project-id' = '"
+                            + BIG_QUERY_PROJECT_ID
+                            + "',"
+                            + "  'dataset' = 'TestDataSet',"
+                            + "  'table-create-if-not-exists' = 'true',"
+                            + "  'table' = 'test-table'"
+                            + ")")
+            .await();
+
+    BigDecimal[] decimalArray = new BigDecimal[] {BigDecimal.valueOf(12233.12), BigDecimal.TEN};
+
+    assertThatThrownBy(() ->
+    tableEnv
+            .fromValues(
+                    schema.toSinkRowDataType(),
+                    row(
+                            "123",
+                            123,
+                            false,
+                            12.345f,
+                            123.4567d,
+                            LocalDateTime.of(2021, 10, 31, 23, 34, 56),
+                            LocalDateTime.of(2021, 10, 31, 23, 34, 56, 987654312),
+                            LocalDate.of(2000, 9, 22),
+                            LocalTime.of(12, 13, 14),
+                            new int[] {1, 2, 3},
+                            Row.of("test", null, LocalDate.of(2030, 9, 25)),
+                            BigDecimal.valueOf(12.312),
+                            decimalArray))
+            .executeInsert("test_table")
+            .await()).hasStackTraceContaining(BigQueryConnectorRuntimeException.class.getCanonicalName() + ":");
   }
 }

--- a/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/FlinkBigQueryConnectorIntegrationTest.java
@@ -3,13 +3,12 @@ package io.aiven.flink.connectors.bigquery;
 import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.aiven.flink.connectors.bigquery.sink.BigQueryConnectorRuntimeException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
-
-import io.aiven.flink.connectors.bigquery.sink.BigQueryConnectorRuntimeException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -122,68 +121,69 @@ public class FlinkBigQueryConnectorIntegrationTest {
     StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
     final ResolvedSchema schema =
-            ResolvedSchema.of(
-                    Column.metadata("string", DataTypes.STRING().nullable(), null, false),
-                    Column.metadata("int", DataTypes.INT().nullable(), null, false),
-                    Column.metadata("boolean", DataTypes.BOOLEAN().nullable(), null, false),
-                    Column.metadata("float", DataTypes.FLOAT().nullable(), null, false),
-                    Column.metadata("double", DataTypes.DOUBLE().nullable(), null, false),
-                    Column.metadata("tmp", DataTypes.TIMESTAMP().nullable(), null, false),
-                    Column.metadata("tmp9", DataTypes.TIMESTAMP(9).nullable(), null, false),
-                    Column.metadata("date", DataTypes.DATE().nullable(), null, false),
-                    Column.metadata("time", DataTypes.TIME().nullable(), null, false),
-                    Column.metadata("array", DataTypes.ARRAY(DataTypes.INT()).nullable(), null, false),
-                    Column.metadata(
-                            "row",
-                            DataTypes.ROW(
-                                    DataTypes.FIELD("string_field", DataTypes.STRING().nullable()),
-                                    DataTypes.FIELD("int_field", DataTypes.INT().nullable()),
-                                    DataTypes.FIELD("date_field", DataTypes.DATE().nullable())),
-                            null,
-                            false),
-                    Column.metadata("decimal", DataTypes.DECIMAL(5, 3).nullable(), null, false),
-                    Column.metadata(
-                            "decimal_array",
-                            DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).nullable()).nullable(),
-                            null,
-                            false));
+        ResolvedSchema.of(
+            Column.metadata("string", DataTypes.STRING().nullable(), null, false),
+            Column.metadata("int", DataTypes.INT().nullable(), null, false),
+            Column.metadata("boolean", DataTypes.BOOLEAN().nullable(), null, false),
+            Column.metadata("float", DataTypes.FLOAT().nullable(), null, false),
+            Column.metadata("double", DataTypes.DOUBLE().nullable(), null, false),
+            Column.metadata("tmp", DataTypes.TIMESTAMP().nullable(), null, false),
+            Column.metadata("tmp9", DataTypes.TIMESTAMP(9).nullable(), null, false),
+            Column.metadata("date", DataTypes.DATE().nullable(), null, false),
+            Column.metadata("time", DataTypes.TIME().nullable(), null, false),
+            Column.metadata("array", DataTypes.ARRAY(DataTypes.INT()).nullable(), null, false),
+            Column.metadata(
+                "row",
+                DataTypes.ROW(
+                    DataTypes.FIELD("string_field", DataTypes.STRING().nullable()),
+                    DataTypes.FIELD("int_field", DataTypes.INT().nullable()),
+                    DataTypes.FIELD("date_field", DataTypes.DATE().nullable())),
+                null,
+                false),
+            Column.metadata("decimal", DataTypes.DECIMAL(5, 3).nullable(), null, false),
+            Column.metadata(
+                "decimal_array",
+                DataTypes.ARRAY(DataTypes.DECIMAL(7, 2).nullable()).nullable(),
+                null,
+                false));
     tableEnv
-            .executeSql(
-                    "CREATE TEMPORARY TABLE test_table ( \n"
-                            + "  `invalid` STRING,\n"
-                            + "  `int` INT,\n"
-                            + "  `boolean` BOOLEAN,\n"
-                            + "  `float` FLOAT,\n"
-                            + "  `double` DOUBLE,\n"
-                            + "  `tmp` TIMESTAMP(3),\n"
-                            + "  `tmp9` TIMESTAMP(9),\n"
-                            + "  `date` DATE,\n"
-                            + "  `time` TIME,\n"
-                            + "  `array` ARRAY<INT>,\n"
-                            + "  `row` ROW<string_field STRING, int_field INT, date_field DATE>,\n"
-                            + "  `decimal` DECIMAL(5, 3),\n"
-                            + "  `decimal_array` ARRAY<DECIMAL(7, 2)>\n"
-                            + ") WITH (\n"
-                            + "  'connector' = 'bigquery',"
-                            + "  'service-account' = '"
-                            + BIG_QUERY_SERVICE_ACCOUNT
-                            + "',"
-                            + "  'project-id' = '"
-                            + BIG_QUERY_PROJECT_ID
-                            + "',"
-                            + "  'dataset' = 'TestDataSet',"
-                            + "  'table-create-if-not-exists' = 'true',"
-                            + "  'table' = 'test-table'"
-                            + ")")
-            .await();
+        .executeSql(
+            "CREATE TEMPORARY TABLE test_table ( \n"
+                + "  `invalid` STRING,\n"
+                + "  `int` INT,\n"
+                + "  `boolean` BOOLEAN,\n"
+                + "  `float` FLOAT,\n"
+                + "  `double` DOUBLE,\n"
+                + "  `tmp` TIMESTAMP(3),\n"
+                + "  `tmp9` TIMESTAMP(9),\n"
+                + "  `date` DATE,\n"
+                + "  `time` TIME,\n"
+                + "  `array` ARRAY<INT>,\n"
+                + "  `row` ROW<string_field STRING, int_field INT, date_field DATE>,\n"
+                + "  `decimal` DECIMAL(5, 3),\n"
+                + "  `decimal_array` ARRAY<DECIMAL(7, 2)>\n"
+                + ") WITH (\n"
+                + "  'connector' = 'bigquery',"
+                + "  'service-account' = '"
+                + BIG_QUERY_SERVICE_ACCOUNT
+                + "',"
+                + "  'project-id' = '"
+                + BIG_QUERY_PROJECT_ID
+                + "',"
+                + "  'dataset' = 'TestDataSet',"
+                + "  'table-create-if-not-exists' = 'true',"
+                + "  'table' = 'test-table'"
+                + ")")
+        .await();
 
     BigDecimal[] decimalArray = new BigDecimal[] {BigDecimal.valueOf(12233.12), BigDecimal.TEN};
 
-    assertThatThrownBy(() ->
-    tableEnv
-            .fromValues(
-                    schema.toSinkRowDataType(),
-                    row(
+    assertThatThrownBy(
+            () ->
+                tableEnv
+                    .fromValues(
+                        schema.toSinkRowDataType(),
+                        row(
                             "123",
                             123,
                             false,
@@ -197,7 +197,8 @@ public class FlinkBigQueryConnectorIntegrationTest {
                             Row.of("test", null, LocalDate.of(2030, 9, 25)),
                             BigDecimal.valueOf(12.312),
                             decimalArray))
-            .executeInsert("test_table")
-            .await()).hasStackTraceContaining(BigQueryConnectorRuntimeException.class.getCanonicalName() + ":");
+                    .executeInsert("test_table")
+                    .await())
+        .hasStackTraceContaining(BigQueryConnectorRuntimeException.class.getCanonicalName() + ":");
   }
 }

--- a/src/test/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/aiven/flink/connectors/bigquery/sink/BigQuerySinkTest.java
@@ -1,13 +1,26 @@
 package io.aiven.flink.connectors.bigquery.sink;
 
+import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,12 +69,14 @@ public class BigQuerySinkTest {
         Arguments.of(
             "array-test",
             new String[] {"array_of_strings"},
-            new DataType[] {DataTypes.ARRAY(DataTypes.STRING()).notNull()}),
+            new DataType[] {DataTypes.ARRAY(DataTypes.STRING().notNull()).notNull()}),
         Arguments.of(
             "array-row-array-string-int-test",
             new String[] {"row_of_string_int"},
             new DataType[] {
-              DataTypes.ARRAY(DataTypes.ROW(DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT()))))
+              DataTypes.ARRAY(
+                      DataTypes.ROW(DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT()).notNull()))
+                          .notNull())
                   .notNull()
             }),
         Arguments.of(
@@ -69,7 +84,8 @@ public class BigQuerySinkTest {
             new String[] {"row_of_string_int"},
             new DataType[] {
               DataTypes.ROW(
-                      DataTypes.ARRAY(DataTypes.ROW(DataTypes.ARRAY(DataTypes.INT()))),
+                      DataTypes.ARRAY(
+                          DataTypes.ROW(DataTypes.ARRAY(DataTypes.INT().notNull())).notNull()),
                       DataTypes.INT())
                   .notNull()
             }),
@@ -101,11 +117,296 @@ public class BigQuerySinkTest {
             new DataType[] {
               DataTypes.ROW(
                       DataTypes.ROW(
-                          DataTypes.ROW(DataTypes.ARRAY(DataTypes.DATE())),
+                          DataTypes.ROW(DataTypes.ARRAY(DataTypes.DATE().notNull())),
                           DataTypes.DECIMAL(4, 3)),
                       DataTypes.STRING(),
                       DataTypes.INT())
                   .notNull()
             }));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validTableDefinitionsProvider")
+  void testValidTableDefinitions(
+      String[] bqColumnNames,
+      DataType[] bqColumnTypes,
+      String[] flinkColumnNames,
+      DataType[] flinkColumnTypes,
+      Expression expression) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(8);
+    StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+    String bigQueryTableName = "test-" + bqColumnNames[0] + "-table-" + System.nanoTime();
+    BigQueryConnectionOptions options =
+        new BigQueryConnectionOptions(
+            BIG_QUERY_PROJECT_ID,
+            DATASET_NAME,
+            bigQueryTableName,
+            true,
+            DeliveryGuarantee.EXACTLY_ONCE,
+            CREDENTIALS);
+    var table = BigQuerySink.ensureTableExists(bqColumnNames, bqColumnTypes, options);
+    List<Column> columns = new ArrayList<>();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < flinkColumnNames.length; i++) {
+      columns.add(Column.metadata(flinkColumnNames[i], flinkColumnTypes[i], null, false));
+      sb.append("`").append(flinkColumnNames[i]).append("` ").append(flinkColumnTypes[i]);
+      if (i < flinkColumnNames.length - 1) {
+        sb.append(",\n");
+      }
+    }
+    final ResolvedSchema schema = ResolvedSchema.of(columns);
+
+    String testTable = "test_table";
+    try {
+      createTemporaryTableWithField(tableEnv, sb.toString(), testTable, bigQueryTableName);
+      executeInsert(tableEnv, schema, testTable, expression);
+    } catch (ExecutionException | InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      table.delete();
+    }
+  }
+
+  static Stream<Arguments> validTableDefinitionsProvider() {
+    return Stream.of(
+        Arguments.of(
+            new String[] {"string", "string1"},
+            new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
+            new String[] {"string"},
+            new DataType[] {DataTypes.STRING()},
+            row("value")),
+        Arguments.of(
+            new String[] {"string", "string1"},
+            new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
+            new String[] {"string1"},
+            new DataType[] {DataTypes.STRING()},
+            row("value")),
+        Arguments.of(
+            new String[] {"string", "string1", "int", "date", "double"},
+            new DataType[] {
+              DataTypes.STRING(),
+              DataTypes.STRING(),
+              DataTypes.INT(),
+              DataTypes.DATE(),
+              DataTypes.DOUBLE()
+            },
+            new String[] {"int", "double"},
+            new DataType[] {DataTypes.INT(), DataTypes.DOUBLE()},
+            row(1, 3.14d)),
+        Arguments.of(
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()), DataTypes.FIELD("f2", DataTypes.INT()))
+            },
+            new String[] {"row"},
+            new DataType[] {DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))},
+            row(Row.of("value1"))),
+        Arguments.of(
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("string", DataTypes.STRING()),
+                  DataTypes.FIELD("int", DataTypes.INT()),
+                  DataTypes.FIELD("date", DataTypes.DATE().notNull()),
+                  DataTypes.FIELD("double", DataTypes.DOUBLE()),
+                  DataTypes.FIELD("decimal", DataTypes.DECIMAL(3, 3)))
+            },
+            new String[] {"row"},
+            new DataType[] {DataTypes.ROW(DataTypes.FIELD("date", DataTypes.DATE().notNull()))},
+            row(Row.of(Instant.now()))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidDefinitionsProvider")
+  void testInvalidTableDefinitions(
+      String[] bqColumnNames,
+      DataType[] bqColumnTypes,
+      String[] flinkColumnNames,
+      DataType[] flinkColumnTypes,
+      Expression expression,
+      String expectedMessage) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(8);
+    StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+    // BigQuery has quotas for number of DDL operations per table name
+    // thus System.nanoTime() helps to avoid exceeding quotas while running test multiple times
+    // during debug
+    String bigQueryTableName = "test-" + bqColumnNames[0] + "-table-" + System.nanoTime();
+    BigQueryConnectionOptions options =
+        new BigQueryConnectionOptions(
+            BIG_QUERY_PROJECT_ID,
+            DATASET_NAME,
+            bigQueryTableName,
+            true,
+            DeliveryGuarantee.EXACTLY_ONCE,
+            CREDENTIALS);
+    var table = BigQuerySink.ensureTableExists(bqColumnNames, bqColumnTypes, options);
+    List<Column> columns = new ArrayList<>();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < flinkColumnNames.length; i++) {
+      columns.add(Column.metadata(flinkColumnNames[i], flinkColumnTypes[i], null, false));
+      sb.append("`").append(flinkColumnNames[i]).append("` ").append(flinkColumnTypes[i]);
+      if (i < flinkColumnNames.length - 1) {
+        sb.append(",\n");
+      }
+    }
+    final ResolvedSchema schema = ResolvedSchema.of(columns);
+
+    String testTable = "test_table";
+    try {
+      assertThatThrownBy(
+              () -> {
+                createTemporaryTableWithField(
+                    tableEnv, sb.toString(), testTable, bigQueryTableName);
+                executeInsert(tableEnv, schema, testTable, expression);
+              })
+          .hasStackTraceContaining(expectedMessage);
+    } finally {
+      table.delete();
+    }
+  }
+
+  static Stream<Arguments> invalidDefinitionsProvider() {
+    return Stream.of(
+        Arguments.of(
+            new String[] {"invalid"},
+            new DataType[] {DataTypes.STRING()},
+            new String[] {"string"},
+            new DataType[] {DataTypes.STRING()},
+            row("value"),
+            "Column #1 has name 'invalid' in BQ while in Flink it has name 'string'"),
+        Arguments.of(
+            new String[] {"string", "invalid"},
+            new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
+            new String[] {"string", "string2"},
+            new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
+            row("value1", "value2"),
+            "Column #2 has name 'invalid' in BQ while in Flink it has name 'string2'"),
+        Arguments.of(
+            new String[] {"field"},
+            new DataType[] {DataTypes.INT()},
+            new String[] {"field"},
+            new DataType[] {DataTypes.STRING()},
+            row("value"),
+            "Column #1 with name 'field' has type 'INT64' in BQ while in Flink it has type 'STRING'"),
+        Arguments.of(
+            new String[] {"field1", "field2"},
+            new DataType[] {DataTypes.STRING(), DataTypes.INT()},
+            new String[] {"field1", "field2"},
+            new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
+            row("value1", "value2"),
+            "Column #2 with name 'field2' has type 'INT64' in BQ while in Flink it has type 'STRING'"),
+        Arguments.of(
+            new String[] {"string"},
+            new DataType[] {DataTypes.STRING().notNull()},
+            new String[] {"string"},
+            new DataType[] {DataTypes.STRING()},
+            row("value"),
+            "Column #1 with name 'string' is not nullable 'STRING' in BQ while in Flink it is nullable 'STRING'"),
+        Arguments.of(
+            new String[] {"string1", "string2"},
+            new DataType[] {DataTypes.STRING().notNull(), DataTypes.STRING().notNull()},
+            new String[] {"string1", "string2"},
+            new DataType[] {DataTypes.STRING().notNull(), DataTypes.STRING()},
+            row("value1", "value2"),
+            "Column #2 with name 'string2' is not nullable 'STRING' in BQ while in Flink it is nullable 'STRING'"),
+        Arguments.of(
+            new String[] {"array"},
+            new DataType[] {DataTypes.ARRAY(DataTypes.STRING().notNull())},
+            new String[] {"array"},
+            new DataType[] {DataTypes.ARRAY(DataTypes.STRING().nullable()).nullable()},
+            row(new String[] {"value1"}),
+            "Type ARRAY<STRING> is not supported (nullable elements of array are not supported by BQ)"),
+        Arguments.of(
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()), DataTypes.FIELD("f2", DataTypes.INT()))
+            },
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("invalid", DataTypes.STRING()),
+                  DataTypes.FIELD("f2", DataTypes.INT()))
+            },
+            row(Row.of("value1", 11)),
+            "Column #1 has name 'row.f1' in BQ while in Flink it has name 'row.invalid'"),
+        Arguments.of(
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()), DataTypes.FIELD("f2", DataTypes.INT()))
+            },
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()),
+                  DataTypes.FIELD("f2", DataTypes.STRING()))
+            },
+            row(Row.of("value1", 11)),
+            "Column #2 with name 'row.f2' has type 'INT64' in BQ while in Flink it has type 'STRING'"),
+        Arguments.of(
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()),
+                  DataTypes.FIELD("f2", DataTypes.INT().notNull()))
+            },
+            new String[] {"row"},
+            new DataType[] {
+              DataTypes.ROW(
+                  DataTypes.FIELD("f1", DataTypes.STRING()), DataTypes.FIELD("f2", DataTypes.INT()))
+            },
+            row(Row.of("value1", 11)),
+            "Column #2 with name 'row.f2' is not nullable 'INT64' in BQ while in Flink it is nullable 'INT64'"),
+        Arguments.of(
+            new String[] {"string", "string1", "int", "date", "double"},
+            new DataType[] {
+              DataTypes.STRING(),
+              DataTypes.STRING(),
+              DataTypes.INT(),
+              DataTypes.DATE(),
+              DataTypes.DOUBLE()
+            },
+            new String[] {"int", "double"},
+            new DataType[] {DataTypes.INT(), DataTypes.DATE()},
+            row(1, 3.14d)));
+  }
+
+  private static void executeInsert(
+      StreamTableEnvironment tableEnv,
+      ResolvedSchema schema,
+      String tableName,
+      Expression expression)
+      throws InterruptedException, ExecutionException {
+    tableEnv.fromValues(schema.toSinkRowDataType(), expression).executeInsert(tableName).await();
+  }
+
+  private static void createTemporaryTableWithField(
+      StreamTableEnvironment tableEnv, String fieldInfo, String tableName, String bigQueryTableName)
+      throws InterruptedException, ExecutionException {
+    tableEnv
+        .executeSql(
+            "CREATE TEMPORARY TABLE "
+                + tableName
+                + " ( \n"
+                + fieldInfo
+                + ") WITH (\n"
+                + "  'connector' = 'bigquery',"
+                + "  'service-account' = '"
+                + BIG_QUERY_SERVICE_ACCOUNT
+                + "',"
+                + "  'project-id' = '"
+                + BIG_QUERY_PROJECT_ID
+                + "',"
+                + "  'dataset' = 'TestDataSet',"
+                + "  'table-create-if-not-exists' = 'true',"
+                + "  'table' = '"
+                + bigQueryTableName
+                + "'"
+                + ")")
+        .await();
   }
 }


### PR DESCRIPTION
Current issue is that in case of schema violations e.g. invalid column name it fails with non human friendly exception like 
```
Caused by: com.google.cloud.bigquery.storage.v1.Exceptions$AppendSerializationError: com.google.cloud.bigquery.storage.v1.Exceptions$AppendSerializationError: INVALID_ARGUMENT: Append serialization failed for writer: projects/aiven-opensource-sandbox/datasets/TestDataSet/tables/test-table/streams/Cic2YjkzODk1MC0wMDAwLTI3NDItODVkMS05NGViMmMwYjA5MDg6czc
	at com.google.cloud.bigquery.storage.v1.SchemaAwareStreamWriter.append(SchemaAwareStreamWriter.java:207)
	at com.google.cloud.bigquery.storage.v1.SchemaAwareStreamWriter.append(SchemaAwareStreamWriter.java:120)
	at com.google.cloud.bigquery.storage.v1.JsonStreamWriter.append(JsonStreamWriter.java:62)
	at io.aiven.flink.connectors.bigquery.sink.BigQueryStreamingAtLeastOnceOutputFormat.append(BigQueryStreamingAtLeastOnceOutputFormat.java:99)
	at io.aiven.flink.connectors.bigquery.sink.BigQueryStreamingAtLeastOnceOutputFormat.append(BigQueryStreamingAtLeastOnceOutputFormat.java:79)
	at io.aiven.flink.connectors.bigquery.sink.AbstractBigQueryOutputFormat.writeRecord(AbstractBigQueryOutputFormat.java:135)
	at io.aiven.flink.connectors.bigquery.sink.AbstractBigQueryOutputFormat.writeRecord(AbstractBigQueryOutputFormat.java:42)
	at org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction.invoke(OutputFormatSinkFunction.java:87)
```
and it is not clear what it is wrong here.

The PR adds description about wrong part, e.g. what column is unexpected
Most of the violations are checked now during validation phase.

Curremt validations:
1. Existence of `required` and `repeated` fields both in Flink and BQ tables
2. `Nullable` fields could be skipped however if they are present in Flink table then they should be in BQ table as well
3. Types should match for the fields with the same name.
4. For `nullable` in BQ table both `nullable ` and `required` could be in Flink table while in case of `required` in BQ table only `required` is allowed. The only exception from this rule is `STRUCT` since there is an issue on Calcite/Flink side which should be fixed first. For that case validation will work on BQ side and it will fail in case of `null` value is trying to be inserted for `required` field